### PR TITLE
Wifi Menu Error Fix

### DIFF
--- a/ui/client/src/components/WifiMenu.js
+++ b/ui/client/src/components/WifiMenu.js
@@ -77,7 +77,7 @@ export default function WifiMenu(props) {
                         setWifiModalOpen(true);
                         handleClose();
                     }}>
-                    <WifiConnection ssid={connectedNetwork.ssid} locked={connectedNetwork.requiresPasskey} />
+                    <WifiConnection ssid={connectedNetwork?.ssid} locked={connectedNetwork?.requiresPasskey} />
                 </MenuItem>
             </>);
             setAvailableWifiNetworks(networks.map((network) => {


### PR DESCRIPTION
## Error

Fixed the following errors found when starting DWE_OS
- `caught (in promise) TypeError: Cannot read properties of null (reading 'ssid')`
- `caught (in promise) TypeError: Cannot read properties of null (reading 'requiresPasskey')`

Error was due to `connectedNetwork` variable being `null` in the beginning, so it couldn't access properties of a null value.

## Fix

Fix was to check if the variable is null before accessing its property. The shorthand way of doing this in JS, is by using a `?`.
- `<WifiConnection ssid={connectedNetwork?.ssid} locked={connectedNetwork?.requiresPasskey} />`
- `                                   here^                           here^                     `
