### PR TITLE
dwe-controls should not have restart=always

### DIFF
--- a/docker/dwe-controls.service
+++ b/docker/dwe-controls.service
@@ -4,7 +4,7 @@ Description=Web Based UVC Control Driver for the DeepWater Exploration exploreHD
 [Service]
 Type=simple
 TimeoutStartSec=0
-Restart=always
+Restart=on-failure
 ExecStart=/usr/bin/docker start dwe-controls
 
 [Install]


### PR DESCRIPTION
A simple systemd service with `Restart=always` will always restart the service even if it is successful, implying it should not terminate. `docker start` simply runs a container and terminates. When restart=always is used with this, it will just try to start it again for no reason, and systemd will say that the service has failed (`failed (Result: start-limit-hit)`), even though the docker container is running fine.

If `Restart=on-failure` is used instead, then systemd will say that it is inactive, which is more accurate since docker start has terminated successfully. Or a oneshot service could be used with `RemainAfterExit=true` so systemd reports it as active but exited, since the container is still running.