### PR TITLE
Docker create does not create an image, it creates a container

### DIFF
--- a/scripts/install-docker.sh
+++ b/scripts/install-docker.sh
@@ -13,8 +13,8 @@ systemctl enable docker
 echo "Pulling docker image"
 docker pull brandondwe/dwe-controls
 
-# Create docker image
-echo "Creating docker image"
+# Create docker container
+echo "Creating docker container"
 if [ "$(docker ps -q -f name=dwe-controls)" ]; then
     docker rm dwe-controls --force
 fi


### PR DESCRIPTION
The echo statement  when the docker container is created falsely claims that it creates a docker image. This is not what is happening, after the image is pulled from docker hub, a container is created from the image.